### PR TITLE
fix: App crashes when user attempts to save new feature #15

### DIFF
--- a/src/main/java/com/owino/desktop/features/FeatureFormView.java
+++ b/src/main/java/com/owino/desktop/features/FeatureFormView.java
@@ -344,7 +344,6 @@ public class FeatureFormView extends ScrollPane {
             IO.println(new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(feature));
             var successAlert = new Alert(Alert.AlertType.INFORMATION);
             successAlert.setContentText("Feature created successfully!");
-            successAlert.getButtonTypes().add(ButtonType.OK);
             if (successAlert.showAndWait().isPresent()){
                 successAlert.close();
                 EventBus.getDefault().post(new OSQANavigationEvents.OpenDashboardEvent());
@@ -352,7 +351,6 @@ public class FeatureFormView extends ScrollPane {
         } else {
             var errorAlert = new Alert(Alert.AlertType.ERROR);
             errorAlert.setContentText("Failed to create feature!");
-            errorAlert.getButtonTypes().add(ButtonType.OK);
             errorAlert.show();
         }
     }


### PR DESCRIPTION
## Description
Deleted ```successAlert.getButtonTypes().add(ButtonType.OK);``` and ```errorAlert.getButtonTypes().add(ButtonType.OK);``` in the file ```src/main/java/com/owino/desktop/features/FeatureFormView.java```

```Alert.AlertType.INFORMATION```  (successAlert) and ```Alert.AlertType.ERROR``` (errorAlert) already contain the ```ButtonType.OK``` hence adding it again crashes with the message ```Children: duplicate children added```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
- [x] Test A: All existing tests pass
- [ ] Test B

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes