### PR TITLE
[#23] Fix navigation after feature creation

### DIFF
--- a/src/main/java/com/owino/desktop/features/FeatureFormView.java
+++ b/src/main/java/com/owino/desktop/features/FeatureFormView.java
@@ -303,7 +303,9 @@ public class FeatureFormView extends ScrollPane {
             successAlert.setContentText("Feature updated successfully!");
             if (successAlert.showAndWait().isPresent()){
                 successAlert.close();
-                EventBus.getDefault().post(new OSQANavigationEvents.OpenDashboardEvent());
+                EventBus.getDefault().post(
+    new OSQANavigationEvents.OpenFeaturesListViewEvent(selectedProduct)
+);
             }
         } else {
             var errorAlert = new Alert(Alert.AlertType.ERROR);
@@ -346,7 +348,9 @@ public class FeatureFormView extends ScrollPane {
             successAlert.setContentText("Feature created successfully!");
             if (successAlert.showAndWait().isPresent()){
                 successAlert.close();
-                EventBus.getDefault().post(new OSQANavigationEvents.OpenDashboardEvent());
+                EventBus.getDefault().post(
+    new OSQANavigationEvents.OpenFeaturesListViewEvent(selectedProduct)
+);
             }
         } else {
             var errorAlert = new Alert(Alert.AlertType.ERROR);


### PR DESCRIPTION
## Description
Fixes #23

This PR fixes an issue where, after creating a new feature, the application redirects to an incorrect screen (dashboard) instead of the expected product-related feature screen.

The navigation logic has been updated to redirect users to the feature list view of the selected product after creating or updating a feature.

---

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## How Has This Been Tested?
- Manually tested feature creation flow
- Verified that after creating a feature, the app navigates to the correct feature list screen instead of the dashboard

---

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes